### PR TITLE
Restructure CLI to execute core function from CLI::EnvFileConsolidator

### DIFF
--- a/lib/dotenvious.rb
+++ b/lib/dotenvious.rb
@@ -1,4 +1,6 @@
 module Dotenvious
+  DEFAULT_ENV_FILE = '.env'
+  DEFAULT_EXAMPLE_ENV_FILE = '.example-env'
   ENV = {}
   ENV_EXAMPLE = {}
   CONFIG = {}

--- a/lib/dotenvious/cli/env_file_consolidator.rb
+++ b/lib/dotenvious/cli/env_file_consolidator.rb
@@ -1,0 +1,36 @@
+require_relative '../loaders/environments'
+require_relative '../missing_variable_finder'
+require_relative '../prompter'
+require_relative '../loaders/configuration'
+
+module Dotenvious
+  module CLI
+    class EnvFileConsolidator
+      def run
+        Loaders::Configuration.new.load
+        Loaders::Environments.new.load_envs
+        unless all_vars_present? && all_vars_match?
+          alert_user
+          decision = STDIN.gets.strip
+          Prompter.run if decision.downcase == 'y'
+        end
+      end
+
+      private
+
+      attr_reader :filename
+
+      def alert_user
+        puts "You have missing ENV variables. Examime them? [y/n]"
+      end
+
+      def all_vars_present?
+        !MissingVariableFinder.required_vars_missing?
+      end
+
+      def all_vars_match?
+        !MismatchedVariableFinder.mismatched_vars?
+      end
+    end
+  end
+end

--- a/lib/dotenvious/cli/main.rb
+++ b/lib/dotenvious/cli/main.rb
@@ -1,20 +1,11 @@
-require_relative '../loaders/environments'
-require_relative '../missing_variable_finder'
-require_relative '../prompter'
-require_relative '../loaders/configuration'
-require 'pry'
+require_relative 'env_file_consolidator'
+
 module Dotenvious
   module CLI
     class Main
       def run
         if ARGV[0].to_s.empty?
-          Loaders::Configuration.new.load
-          Loaders::Environments.new.load_envs
-          unless all_vars_present? && all_vars_match?
-            alert_user
-            decision = STDIN.gets.strip
-            Prompter.run if decision.downcase == 'y'
-          end
+          EnvFileConsolidator.new.run
         else
           ask_user_to_remove_flags
         end
@@ -22,20 +13,10 @@ module Dotenvious
 
       private
 
-      def alert_user
-        puts "You have missing ENV variables. Examime them? [y/n]"
-      end
+      attr_reader :filename
 
       def ask_user_to_remove_flags
         puts "dotenvious does not have flags at this time. Run 'dotenvious' without flags to get the main functionality."
-      end
-
-      def all_vars_present?
-        !MissingVariableFinder.required_vars_missing?
-      end
-
-      def all_vars_match?
-        !MismatchedVariableFinder.mismatched_vars?
       end
 
       def abort

--- a/lib/dotenvious/cli/main.rb
+++ b/lib/dotenvious/cli/main.rb
@@ -12,12 +12,16 @@ module Dotenvious
       end
 
       def run
-        Loaders::Configuration.new.load
-        Loaders::Environments.new(filename).load_envs
-        unless all_vars_present? && all_vars_match?
-          alert_user
-          decision = STDIN.gets.strip
-          Prompter.run if decision.downcase == 'y'
+        if ARGV[0].to_s.empty?
+          Loaders::Configuration.new.load
+          Loaders::Environments.new(filename).load_envs
+          unless all_vars_present? && all_vars_match?
+            alert_user
+            decision = STDIN.gets.strip
+            Prompter.run if decision.downcase == 'y'
+          end
+        else
+          ask_user_to_remove_flags
         end
       end
 
@@ -27,6 +31,10 @@ module Dotenvious
 
       def alert_user
         puts "You have missing ENV variables. Examime them? [y/n]"
+      end
+
+      def ask_user_to_remove_flags
+        puts "dotenvious does not have flags at this time. Run 'dotenvious' without flags to get the main functionality."
       end
 
       def all_vars_present?

--- a/lib/dotenvious/cli/main.rb
+++ b/lib/dotenvious/cli/main.rb
@@ -6,15 +6,10 @@ require 'pry'
 module Dotenvious
   module CLI
     class Main
-      def initialize
-        #figure out which file - for now can just look .env.example or .example-env
-        @filename = '.example-env' # or .env-example
-      end
-
       def run
         if ARGV[0].to_s.empty?
           Loaders::Configuration.new.load
-          Loaders::Environments.new(filename).load_envs
+          Loaders::Environments.new.load_envs
           unless all_vars_present? && all_vars_match?
             alert_user
             decision = STDIN.gets.strip
@@ -26,8 +21,6 @@ module Dotenvious
       end
 
       private
-
-      attr_reader :filename
 
       def alert_user
         puts "You have missing ENV variables. Examime them? [y/n]"

--- a/lib/dotenvious/loaders/env.rb
+++ b/lib/dotenvious/loaders/env.rb
@@ -3,6 +3,10 @@ module Dotenvious
     class Env < Environment
       private
 
+      def filename
+        DEFAULT_ENV_FILE
+      end
+
       def environment
         Dotenvious::ENV
       end

--- a/lib/dotenvious/loaders/environment.rb
+++ b/lib/dotenvious/loaders/environment.rb
@@ -1,10 +1,6 @@
 module Dotenvious
   module Loaders
     class Environment
-      def initialize(filename)
-        @filename = filename
-      end
-
       def load
         #took from Dotenv source code whoops
         file.each do |line|
@@ -18,11 +14,13 @@ module Dotenvious
         raise "environment must be defined in child class"
       end
 
-      def file
-        File.read(@filename).split("\n")
+      def filename
+        raise "fileame must be defined in child class"
       end
 
-      attr_reader :filename
+      def file
+        File.read(filename).split("\n")
+      end
     end
   end
 end

--- a/lib/dotenvious/loaders/environments.rb
+++ b/lib/dotenvious/loaders/environments.rb
@@ -4,19 +4,10 @@ require_relative 'env'
 module Dotenvious
   module Loaders
     class Environments
-
-      def initialize(filename)
-        @filename = filename
-      end
-
       def load_envs
-        Env.new('.env').load
-        Example.new(filename).load
+        Env.new.load
+        Example.new.load
       end
-
-      private
-
-      attr_reader :filename
     end
   end
 end

--- a/lib/dotenvious/loaders/example.rb
+++ b/lib/dotenvious/loaders/example.rb
@@ -5,6 +5,10 @@ module Dotenvious
     class Example < Environment
       private
 
+      def filename
+        DEFAULT_EXAMPLE_ENV_FILE
+      end
+
       def environment
         Dotenvious::ENV_EXAMPLE
       end

--- a/spec/dotenvious/cli/env_file_consolidator_spec.rb
+++ b/spec/dotenvious/cli/env_file_consolidator_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe Dotenvious::CLI::EnvFileConsolidator do
+  describe '.new' do
+    xit 'determines the correct file to use as example' do
+      # future release work
+    end
+  end
+
+  describe '#run' do
+    context 'with no flags' do
+      before do
+        allow(File).to receive(:read).and_return("")
+      end
+
+      it 'loads the environment & example environment variables' do
+        expect_any_instance_of(Dotenvious::Loaders::Environments).to receive(:load_envs)
+
+        described_class.new.run
+      end
+
+      context 'when there are ENV vars missing' do
+        context 'and the user wants to append them' do
+          it 'begins the Prompter' do
+            io_object = double
+            expect(STDIN).to receive(:gets).and_return('y')
+            expect_any_instance_of(described_class).to receive(:all_vars_present?).and_return false
+            expect(Dotenvious::Prompter).to receive(:run)#.and_return false
+            described_class.new.run
+          end
+        end
+
+        context 'but the user does not care' do
+          it 'quits' do
+            expect(STDIN).to receive(:gets).and_return('n')
+            expect_any_instance_of(described_class).to receive(:all_vars_present?).and_return false
+            expect(Dotenvious::Prompter).not_to receive(:run)#.and_return false
+
+            described_class.new.run
+          end
+        end
+      end
+
+      #Keep
+      context 'when there are no ENV vars missing or mismatched' do
+        it 'does nothing' do
+          expect_any_instance_of(described_class).to receive(:all_vars_present?).and_return true
+          expect_any_instance_of(described_class).to receive(:all_vars_match?).and_return true
+
+          expect { described_class.new.run }.to_not raise_error
+        end
+      end
+    end
+  end
+end

--- a/spec/dotenvious/cli/main_spec.rb
+++ b/spec/dotenvious/cli/main_spec.rb
@@ -8,42 +8,58 @@ describe Dotenvious::CLI::Main do
   end
 
   describe '#run' do
-    before do
-      allow(File).to receive(:read).and_return("")
-    end
-    it 'loads the environment & example environment variables' do
-      expect_any_instance_of(Dotenvious::Loaders::Environments).to receive(:load_envs)
+    context 'with no flags' do
+      before do
+        allow(File).to receive(:read).and_return("")
+      end
 
-      described_class.new.run
-    end
+      it 'loads the environment & example environment variables' do
+        expect_any_instance_of(Dotenvious::Loaders::Environments).to receive(:load_envs)
 
-    context 'when there are ENV vars missing' do
-      context 'and the user wants to append them' do
-        it 'begins the Prompter' do
-          io_object = double
-          expect(STDIN).to receive(:gets).and_return('y')
-          expect_any_instance_of(described_class).to receive(:all_vars_present?).and_return false
-          expect(Dotenvious::Prompter).to receive(:run)#.and_return false
-          described_class.new.run
+        described_class.new.run
+      end
+
+      context 'when there are ENV vars missing' do
+        context 'and the user wants to append them' do
+          it 'begins the Prompter' do
+            io_object = double
+            expect(STDIN).to receive(:gets).and_return('y')
+            expect_any_instance_of(described_class).to receive(:all_vars_present?).and_return false
+            expect(Dotenvious::Prompter).to receive(:run)#.and_return false
+            described_class.new.run
+          end
+        end
+
+        context 'but the user does not care' do
+          it 'quits' do
+            expect(STDIN).to receive(:gets).and_return('n')
+            expect_any_instance_of(described_class).to receive(:all_vars_present?).and_return false
+            expect(Dotenvious::Prompter).not_to receive(:run)#.and_return false
+
+            described_class.new.run
+          end
         end
       end
-      context 'but the user does not care' do
-        it 'quits' do
-          expect(STDIN).to receive(:gets).and_return('n')
-          expect_any_instance_of(described_class).to receive(:all_vars_present?).and_return false
-          expect(Dotenvious::Prompter).not_to receive(:run)#.and_return false
 
-          described_class.new.run
+      context 'when there are no ENV vars missing or mismatched' do
+        it 'does nothing' do
+          expect_any_instance_of(described_class).to receive(:all_vars_present?).and_return true
+          expect_any_instance_of(described_class).to receive(:all_vars_match?).and_return true
+
+          expect { described_class.new.run }.to_not raise_error
         end
       end
     end
 
-    context 'when there are no ENV vars missing or mismatched' do
-      it 'does nothing' do
-        expect_any_instance_of(described_class).to receive(:all_vars_present?).and_return true
-        expect_any_instance_of(described_class).to receive(:all_vars_match?).and_return true
+    context 'when option flags are given' do
+      before do
+        stub_const('ARGV', ['--test'])
+      end
 
-        expect { described_class.new.run }.to_not raise_error
+      it 'tells the user to try again without flags' do
+        expect_any_instance_of(described_class).to receive(:ask_user_to_remove_flags)
+
+        described_class.new.run
       end
     end
   end

--- a/spec/dotenvious/cli/main_spec.rb
+++ b/spec/dotenvious/cli/main_spec.rb
@@ -1,53 +1,16 @@
 require 'spec_helper'
 
 describe Dotenvious::CLI::Main do
-  describe '.new' do
-    xit 'determines the correct file to use as example' do
-      # future release work
-    end
-  end
-
   describe '#run' do
     context 'with no flags' do
       before do
         allow(File).to receive(:read).and_return("")
       end
 
-      it 'loads the environment & example environment variables' do
-        expect_any_instance_of(Dotenvious::Loaders::Environments).to receive(:load_envs)
+      it 'begins the EnvFileConsolidator' do
+        expect_any_instance_of(Dotenvious::CLI::EnvFileConsolidator).to receive(:run)
 
         described_class.new.run
-      end
-
-      context 'when there are ENV vars missing' do
-        context 'and the user wants to append them' do
-          it 'begins the Prompter' do
-            io_object = double
-            expect(STDIN).to receive(:gets).and_return('y')
-            expect_any_instance_of(described_class).to receive(:all_vars_present?).and_return false
-            expect(Dotenvious::Prompter).to receive(:run)#.and_return false
-            described_class.new.run
-          end
-        end
-
-        context 'but the user does not care' do
-          it 'quits' do
-            expect(STDIN).to receive(:gets).and_return('n')
-            expect_any_instance_of(described_class).to receive(:all_vars_present?).and_return false
-            expect(Dotenvious::Prompter).not_to receive(:run)#.and_return false
-
-            described_class.new.run
-          end
-        end
-      end
-
-      context 'when there are no ENV vars missing or mismatched' do
-        it 'does nothing' do
-          expect_any_instance_of(described_class).to receive(:all_vars_present?).and_return true
-          expect_any_instance_of(described_class).to receive(:all_vars_match?).and_return true
-
-          expect { described_class.new.run }.to_not raise_error
-        end
       end
     end
 

--- a/spec/dotenvious/loaders/env_spec.rb
+++ b/spec/dotenvious/loaders/env_spec.rb
@@ -1,23 +1,17 @@
 require 'spec_helper'
 
 describe Dotenvious::Loaders::Env do
-  describe '.new' do
-    it 'takes one argument' do
-      expect{ described_class.new('test') }.to_not raise_error
-    end
-  end
-
   describe '#load' do
-    it 'loads files from its .new argument' do
-      expect(File).to receive(:read).with('test').and_return ""
+    it 'loads files from .env' do
+      expect(File).to receive(:read).with('.env').and_return ""
 
-      described_class.new('test').load
+      described_class.new.load
     end
 
     it 'passes those arguments to Dotenvious::ENV_EXAMPLE' do
       expect(File).to receive(:read).and_return "TEST=123\nEXAMPLE=234"
 
-      described_class.new('test').load
+      described_class.new.load
 
       expect(Dotenvious::ENV['TEST']).to eq '123'
       expect(Dotenvious::ENV['EXAMPLE']).to eq '234'

--- a/spec/dotenvious/loaders/environments_spec.rb
+++ b/spec/dotenvious/loaders/environments_spec.rb
@@ -1,18 +1,12 @@
 require 'spec_helper'
 
 describe Dotenvious::Loaders::Environments do
-  describe '#initialize' do
-    it 'takes 1 argument' do
-      expect { described_class.new('test') }.to_not raise_error
-    end
-  end
-
   describe '#load_envs' do
     it 'loads from Dotenv as well as Loaders::Example' do
       expect_any_instance_of(Dotenvious::Loaders::Example).to receive(:load)
       expect_any_instance_of(Dotenvious::Loaders::Env).to receive(:load)
 
-      described_class.new('test').load_envs
+      described_class.new.load_envs
     end
   end
 end

--- a/spec/dotenvious/loaders/example_spec.rb
+++ b/spec/dotenvious/loaders/example_spec.rb
@@ -1,23 +1,20 @@
 require 'spec_helper'
 
 describe Dotenvious::Loaders::Example do
-  describe '.new' do
-    it 'takes one argument' do
-      expect{ described_class.new('test') }.to_not raise_error
-    end
-  end
-
   describe '#load' do
-    it 'loads files from its .new argument' do
-      expect(File).to receive(:read).with('test').and_return ""
+    before do
+      stub_const('Dotenvious::DEFAULT_EXAMPLE_ENV_FILE', '.example-env')
+    end
+    it 'loads files from Dotenvious::DEFAULT_EXAMPLE_ENV_FILE' do
+      expect(File).to receive(:read).with('.example-env').and_return ""
 
-      described_class.new('test').load
+      described_class.new.load
     end
 
     it 'passes those arguments to Dotenvious::ENV_EXAMPLE' do
       expect(File).to receive(:read).and_return "TEST=123\nEXAMPLE=234"
 
-      described_class.new('test').load
+      described_class.new.load
 
       expect(Dotenvious::ENV_EXAMPLE['TEST']).to eq '123'
       expect(Dotenvious::ENV_EXAMPLE['EXAMPLE']).to eq '234'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,3 +18,5 @@ RSpec.configure do |config|
     $stdout = original_stdout
   end
 end
+
+ARGV = []


### PR DESCRIPTION
## What's Up

The Goal of this PR is to lay down foundation for Dotenvious to invoke different functionality based on the flags that are passed in along during the command line execution.

## What This Does

This PR evolves the CLI to only execute the current `.env`/`.example-env` consolidation path from a non-initial class, `CLI::EnvFileConsolidator`. As the app evolves, different classes in the CLI scope will interact with the user and their files to achieve different things.

Until we add another flag or piece of core functionality, I've disabled the ability to add any flags whatsoever until I integrate a more comprehensive system for handling `ARGV`'s.

Additionally, this PR moves some underlying foundation regarding which files to read from (currently exclusively `.env` and `.example-env`) into constants `DEFAULT_ENV_FILE` and `DEFAULT_EXAMPLE_ENV_FILE`. This was because I was doing some weird passing of arguments from CLI::Main to some Loaders which was annoying me. (A more comprehensive change will be coming in the future, when we add the ability to pick what primary and example environment files the user wants to read from.)