### PR TITLE
Add option to sort .env file

### DIFF
--- a/lib/dotenvious/cli/env_file_sorter.rb
+++ b/lib/dotenvious/cli/env_file_sorter.rb
@@ -1,0 +1,24 @@
+require_relative '../loaders/env'
+
+module Dotenvious
+  module CLI
+    class EnvFileSorter
+      def run
+        Loaders::Env.new.load
+        puts "Sorting..."
+        File.open('.env', 'w') do |file|
+          file.write(sorted_env_text)
+        end
+        puts 'Your .env file is now neat and orderly. Enjoy!'
+      end
+
+      private
+
+      def sorted_env_text
+        ENV.sort.map do |(key, value)|
+          "#{key}=#{value}"
+        end.join("\n")
+      end
+    end
+  end
+end

--- a/lib/dotenvious/cli/main.rb
+++ b/lib/dotenvious/cli/main.rb
@@ -1,4 +1,5 @@
 require_relative 'env_file_consolidator'
+require_relative 'env_file_sorter'
 
 module Dotenvious
   module CLI
@@ -6,6 +7,8 @@ module Dotenvious
       def run
         if ARGV[0].to_s.empty?
           EnvFileConsolidator.new.run
+        elsif ARGV[0].to_s == '--sort'
+          EnvFileSorter.new.run
         else
           ask_user_to_remove_flags
         end

--- a/spec/dotenvious/cli/env_file_sorter_spec.rb
+++ b/spec/dotenvious/cli/env_file_sorter_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe Dotenvious::CLI::EnvFileSorter do
+  describe '#run' do
+    it "sorts the key-value pairs back into .env" do
+      expect_any_instance_of(Dotenvious::Loaders::Env).to receive(:load).and_return true
+
+      stub_const('Dotenvious::ENV', {'TEST' => 'same', 'ABC' => '123'} )
+
+      fake_file = double
+      expect(fake_file).to receive(:write).with("ABC=123\nTEST=same")
+      expect(File).to receive(:open).with('.env', 'w').and_yield fake_file
+
+      described_class.new.run
+    end
+  end
+end


### PR DESCRIPTION
## What's Up

Issue #4 outlines the need for an option to sort key/values in the `.env` file.

## What This Does

By running `dotenvious --sort`, users will be able to sort the key/values in `.env` that may not be in order after running a usual `dotenvious` command.