### PR TITLE
[#5] Added safety check for loading .env and .env-example

### DIFF
--- a/lib/dotenvious/errors.rb
+++ b/lib/dotenvious/errors.rb
@@ -1,0 +1,9 @@
+module Dotenvious
+  class FileNotFoundError < ArgumentError
+    attr_reader :file
+    def initialize(filename)
+      @file = filename
+      super
+    end
+  end
+end

--- a/lib/dotenvious/loaders/environment.rb
+++ b/lib/dotenvious/loaders/environment.rb
@@ -1,3 +1,5 @@
+require_relative "../errors"
+
 module Dotenvious
   module Loaders
     class Environment
@@ -19,6 +21,9 @@ module Dotenvious
       end
 
       def file
+        if !File.exist?(filename)
+          raise Dotenvious::FileNotFoundError.new(filename)
+        end
         File.read(filename).split("\n")
       end
     end

--- a/lib/dotenvious/loaders/environments.rb
+++ b/lib/dotenvious/loaders/environments.rb
@@ -5,8 +5,16 @@ module Dotenvious
   module Loaders
     class Environments
       def load_envs
-        Env.new.load
-        Example.new.load
+        begin
+          Env.new.load
+        rescue Dotenvious::FileNotFoundError => ex
+          STDERR.puts "#{ex.file} not found"
+        end
+        begin
+          Example.new.load
+        rescue Dotenvious::FileNotFoundError => ex
+          STDERR.puts "#{ex.file} not found"
+        end
       end
     end
   end


### PR DESCRIPTION
Might be a little overkill, but does the job.
If the .env or .env-example are missing, it'll log a message to STDERR. 

Nice part is it'll still write a .env even if it doesn't exist yet. 