### PR TITLE
Alert user if critical file not present

### DIFF
--- a/lib/dotenvious/loaders/environment.rb
+++ b/lib/dotenvious/loaders/environment.rb
@@ -3,12 +3,20 @@ module Dotenvious
     class Environment
       def load
         #took from Dotenv source code whoops
+        if file_missing?
+          puts "This repo does not have an #{filename} file"
+          return
+        end
         file.each do |line|
           environment[$1] = $2 if line =~ /\A([\w_]+)=(.*)\z/
         end
       end
 
       private
+
+      def file_missing?
+        !File.exists?(filename)
+      end
 
       def environment
         raise "environment must be defined in child class"

--- a/spec/dotenvious/loaders/env_spec.rb
+++ b/spec/dotenvious/loaders/env_spec.rb
@@ -2,19 +2,33 @@ require 'spec_helper'
 
 describe Dotenvious::Loaders::Env do
   describe '#load' do
-    it 'loads files from .env' do
-      expect(File).to receive(:read).with('.env').and_return ""
-
-      described_class.new.load
+    context 'when .env are not present' do
+      before do
+        expect(File).to receive(:exists?).and_return false
+      end
+      it 'aborts the process' do
+        described_class.new.load
+      end
     end
 
-    it 'passes those arguments to Dotenvious::ENV_EXAMPLE' do
-      expect(File).to receive(:read).and_return "TEST=123\nEXAMPLE=234"
+    context 'when .env is present' do
+      before do
+        expect(File).to receive(:exists?).and_return true
+      end
+      it 'loads files from .env' do
+        expect(File).to receive(:read).with('.env').and_return ""
 
-      described_class.new.load
+        described_class.new.load
+      end
 
-      expect(Dotenvious::ENV['TEST']).to eq '123'
-      expect(Dotenvious::ENV['EXAMPLE']).to eq '234'
+      it 'passes those arguments to Dotenvious::ENV_EXAMPLE' do
+        expect(File).to receive(:read).and_return "TEST=123\nEXAMPLE=234"
+
+        described_class.new.load
+
+        expect(Dotenvious::ENV['TEST']).to eq '123'
+        expect(Dotenvious::ENV['EXAMPLE']).to eq '234'
+      end
     end
   end
 end

--- a/spec/dotenvious/loaders/example_spec.rb
+++ b/spec/dotenvious/loaders/example_spec.rb
@@ -2,22 +2,36 @@ require 'spec_helper'
 
 describe Dotenvious::Loaders::Example do
   describe '#load' do
-    before do
-      stub_const('Dotenvious::DEFAULT_EXAMPLE_ENV_FILE', '.example-env')
+    context 'when example-env does not exist' do
+      before do
+        expect(File).to receive(:exists?).and_return false
+      end
+
+      it 'aborts the process' do
+        described_class.new.load
+      end
     end
-    it 'loads files from Dotenvious::DEFAULT_EXAMPLE_ENV_FILE' do
-      expect(File).to receive(:read).with('.example-env').and_return ""
 
-      described_class.new.load
-    end
+    context 'when example-env exists' do
+      before do
+        expect(File).to receive(:exists?).and_return true
+        stub_const('Dotenvious::DEFAULT_EXAMPLE_ENV_FILE', '.example-env')
+      end
 
-    it 'passes those arguments to Dotenvious::ENV_EXAMPLE' do
-      expect(File).to receive(:read).and_return "TEST=123\nEXAMPLE=234"
+      it 'loads files from Dotenvious::DEFAULT_EXAMPLE_ENV_FILE' do
+        expect(File).to receive(:read).with('.example-env').and_return ""
 
-      described_class.new.load
+        described_class.new.load
+      end
 
-      expect(Dotenvious::ENV_EXAMPLE['TEST']).to eq '123'
-      expect(Dotenvious::ENV_EXAMPLE['EXAMPLE']).to eq '234'
+      it 'passes those arguments to Dotenvious::ENV_EXAMPLE' do
+        expect(File).to receive(:read).and_return "TEST=123\nEXAMPLE=234"
+
+        described_class.new.load
+
+        expect(Dotenvious::ENV_EXAMPLE['TEST']).to eq '123'
+        expect(Dotenvious::ENV_EXAMPLE['EXAMPLE']).to eq '234'
+      end
     end
   end
 end


### PR DESCRIPTION
## What's Up

Currently, if the user does not have the `.env` or `.example-env` files, the executable just crashes.

## What This Does

This PR makes a change to `Loaders::Environments` to let the user know that the environment file is missing. (If the user is missing `.example-env`, it will quite by virtue of no variables from that file missing in `.env`.)