### PR TITLE
Always run main dotenvious process even with --sort

### DIFF
--- a/lib/dotenvious/cli/main.rb
+++ b/lib/dotenvious/cli/main.rb
@@ -5,21 +5,10 @@ module Dotenvious
   module CLI
     class Main
       def run
-        if ARGV[0].to_s.empty?
-          EnvFileConsolidator.new.run
-        elsif ARGV[0].to_s == '--sort'
+        EnvFileConsolidator.new.run
+        if ARGV[0].to_s == '--sort'
           EnvFileSorter.new.run
-        else
-          ask_user_to_remove_flags
         end
-      end
-
-      private
-
-      attr_reader :filename
-
-      def ask_user_to_remove_flags
-        puts "dotenvious does not have flags at this time. Run 'dotenvious' without flags to get the main functionality."
       end
     end
   end

--- a/lib/dotenvious/loaders/environment.rb
+++ b/lib/dotenvious/loaders/environment.rb
@@ -2,6 +2,7 @@ module Dotenvious
   module Loaders
     class Environment
       def load
+        return unless environment.keys.empty?
         #took from Dotenv source code whoops
         if file_missing?
           puts "This repo does not have an #{filename} file"

--- a/spec/dotenvious/cli/main_spec.rb
+++ b/spec/dotenvious/cli/main_spec.rb
@@ -15,14 +15,31 @@ describe Dotenvious::CLI::Main do
     end
 
     context 'when option flags are given' do
-      before do
-        stub_const('ARGV', ['--test'])
+      context 'and the flag is not implemented' do
+        before do
+          stub_const('ARGV', ['--test'])
+        end
+
+        it 'ignores the flag and runs main process' do
+          expect_any_instance_of(Dotenvious::CLI::EnvFileConsolidator).to receive(:run)
+
+          described_class.new.run
+        end
       end
 
-      it 'tells the user to try again without flags' do
-        expect_any_instance_of(described_class).to receive(:ask_user_to_remove_flags)
+      context 'and the flag is implemented' do
+        context '--sort' do
+          before do
+            stub_const('ARGV', ['--sort'])
+          end
 
-        described_class.new.run
+          it 'runs EnvFileSorter after main process' do
+            expect_any_instance_of(Dotenvious::CLI::EnvFileConsolidator).to receive(:run)
+            expect_any_instance_of(Dotenvious::CLI::EnvFileSorter).to receive(:run)
+
+            described_class.new.run
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## What's Up

Dotenvious currently will run its sort functionality or the main functionality exclusively - you can't run one command to do both! 

## What This Does

This PR changes the `--sort` flag (and any other future flag) to always run the core functionality before doing the optional flag (in this case, sorting).