### PR TITLE
Rely on OptionParser for... parsing options

### DIFF
--- a/lib/dotenvious/cli/main.rb
+++ b/lib/dotenvious/cli/main.rb
@@ -1,13 +1,42 @@
+require 'optparse'
 require_relative 'env_file_consolidator'
 require_relative 'env_file_sorter'
 
 module Dotenvious
   module CLI
     class Main
+      def initialize
+        @options = {}
+      end
+
       def run
+        parse_options
         EnvFileConsolidator.new.run
-        if ARGV[0].to_s == '--sort'
-          EnvFileSorter.new.run
+        EnvFileSorter.new.run if options[:sort]
+      end
+
+      private
+
+      attr_accessor :options
+
+      def parse_options
+        parser = OptionParser.new do |opts|
+          opts.banner = "How to use Dotenvious:"
+
+          opts.on('-s', '--sort', 'Sort .env file by key names alphabetically') do
+            options[:sort] = true
+          end
+
+          opts.on('-h', '--help', 'View this message') do
+            puts opts
+            exit
+          end
+        end
+
+        begin
+          parser.parse!
+        rescue OptionParser::InvalidOption => e
+          puts "Warning #{e}"
         end
       end
     end


### PR DESCRIPTION
Before, dotenvious was directly inspecting ARGV which is pretty bad practice.
OptionParser gives us move flexibility around implementing flags.