### PR TITLE
Allow users to load from YML configurations

### DIFF
--- a/lib/dotenvious/loaders/environments.rb
+++ b/lib/dotenvious/loaders/environments.rb
@@ -1,4 +1,5 @@
 require_relative 'dotenv_file'
+require_relative 'yaml_file'
 
 module Dotenvious
   module Loaders
@@ -9,7 +10,12 @@ module Dotenvious
 
       def load_environments
         ENV.merge!(DotenvFile.load_from('.env'))
-        ENV_EXAMPLE.merge!(DotenvFile.load_from(example_file))
+        example_env = if example_file.match(/\.ya?ml/)
+          YamlFile.load_from(example_file)
+        else
+          DotenvFile.load_from(example_file)
+        end
+        ENV_EXAMPLE.merge!(example_env)
       end
 
       private

--- a/lib/dotenvious/loaders/environments.rb
+++ b/lib/dotenvious/loaders/environments.rb
@@ -10,12 +10,8 @@ module Dotenvious
 
       def load_environments
         ENV.merge!(DotenvFile.load_from('.env'))
-        example_env = if example_file.match(/\.ya?ml/)
-          YamlFile.load_from(example_file)
-        else
-          DotenvFile.load_from(example_file)
-        end
-        ENV_EXAMPLE.merge!(example_env)
+        environment_loader = example_file.match(/\.ya?ml/) ? YamlFile : DotenvFile
+        ENV_EXAMPLE.merge!(environment_loader.load_from(example_file))
       end
 
       private

--- a/lib/dotenvious/loaders/yaml_file.rb
+++ b/lib/dotenvious/loaders/yaml_file.rb
@@ -1,0 +1,49 @@
+require 'yaml'
+
+module Dotenvious
+  module Loaders
+    class YamlFile
+      def self.load_from(filename)
+        new(filename).load
+      end
+
+      def initialize(filename)
+        @filename = filename
+      end
+
+      def load
+        if file_missing?
+          puts "This repo does not have an #{filename} file"
+          return {}
+        end
+        Hash.new.tap do |environment|
+          environment_variables.each do |(k, v)|
+            environment[k] = v.to_s
+          end
+        end
+      end
+
+      private
+
+      attr_reader :filename
+
+      def file_missing?
+        !File.exists?(filename)
+      end
+
+      def file
+        YAML.load_file(filename)
+      end
+
+      def environment_variables
+        begin
+          file['machine']['environment']
+        rescue NoMethodError => e
+          puts "Error: #{filename} does not have a proper machine environment setup."
+          puts "The program will now exit."
+          exit
+        end
+      end
+    end
+  end
+end

--- a/spec/dotenvious/loaders/environments_spec.rb
+++ b/spec/dotenvious/loaders/environments_spec.rb
@@ -24,6 +24,22 @@ describe Dotenvious::Loaders::Environments do
 
         described_class.new({example_file: '.my.example.file'}).load_environments
       end
+
+      context 'which is a yml/yaml' do
+        it 'loads the yml correctly' do
+          expect(Dotenvious::Loaders::DotenvFile).to receive(:load_from).with('.env').and_return({})
+          expect(Dotenvious::Loaders::YamlFile).to receive(:load_from).with('example.yml').and_return({})
+
+          described_class.new({example_file: 'example.yml'}).load_environments
+        end
+
+        it 'also loads yaml files' do
+          expect(Dotenvious::Loaders::DotenvFile).to receive(:load_from).with('.env').and_return({})
+          expect(Dotenvious::Loaders::YamlFile).to receive(:load_from).with('example.yaml').and_return({})
+
+          described_class.new({example_file: 'example.yaml'}).load_environments
+        end
+      end
     end
   end
 end

--- a/spec/dotenvious/loaders/yaml_file_spec.rb
+++ b/spec/dotenvious/loaders/yaml_file_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Dotenvious::Loaders::YamlFile do
+  describe '.load_from' do
+    context 'given a file which does not exist' do
+      before do
+        expect(File).to receive(:exists?).and_return false
+      end
+      it 'aborts the process' do
+        described_class.load_from('.env')
+      end
+    end
+
+    context 'given a file which exists' do
+      before do
+        expect(File).to receive(:exists?).and_return true
+      end
+
+      it 'reads the given Yaml format file and returns hash' do
+        expect(YAML).to receive(:load_file).and_return ({
+          "machine" => {
+            "environment" => {
+              "TEST" => 123,
+              "EXAMPLE" => 234
+            }
+          }
+        })
+
+        response = described_class.load_from('production.yaml')
+
+        expect(response['TEST']).to eq '123'
+        expect(response['EXAMPLE']).to eq '234'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What's Up

#12

## What This Does

This PR redirects the `Loaders::Environments` to use a new `Loaders::YamlFile` class to load variables from a YML/YAML file into EXAMPLE_ENV if need be.