### PR TITLE
Allow user to specify which file to write new ENV values to

### DIFF
--- a/lib/dotenvious/cli/env_file_consolidator.rb
+++ b/lib/dotenvious/cli/env_file_consolidator.rb
@@ -6,23 +6,24 @@ require_relative '../loaders/configuration'
 module Dotenvious
   module CLI
     class EnvFileConsolidator
-      def initialize(options = {})
-        @example_file = options[:example_file]
+      def initialize(example_file: DEFAULT_EXAMPLE_ENV_FILE, env_file: DEFAULT_ENV_FILE)
+        @example_file = example_file
+        @env_file = env_file
       end
 
       def run
         Loaders::Configuration.new.load
-        Loaders::Environments.new({example_file: example_file}).load_environments
+        Loaders::Environments.new({example_file: example_file, env_file: env_file}).load_environments
         unless all_vars_present? && all_vars_match?
           alert_user
           decision = STDIN.gets.strip
-          Prompter.run if decision.downcase == 'y'
+          Prompter.new(env_file).run if decision.downcase == 'y'
         end
       end
 
       private
 
-      attr_reader :example_file, :filename
+      attr_reader :example_file, :env_file, :filename
 
       def alert_user
         puts "You have missing ENV variables. Examime them? [y/n]"

--- a/lib/dotenvious/cli/env_file_sorter.rb
+++ b/lib/dotenvious/cli/env_file_sorter.rb
@@ -1,14 +1,20 @@
 module Dotenvious
   module CLI
     class EnvFileSorter
+      def initialize(filename = DEFAULT_ENV_FILE)
+        @filename = filename
+      end
+
       def run
-        File.open('.env', 'w') do |file|
+        File.open(filename, 'w') do |file|
           file.write(sorted_env_text)
         end
-        puts 'Your .env file is now neat and orderly. Enjoy!'
+        puts "Your #{filename} file is now neat and orderly. Enjoy!"
       end
 
       private
+
+      attr_reader :filename
 
       def sorted_env_text
         ENV.sort.map do |(key, value)|

--- a/lib/dotenvious/cli/main.rb
+++ b/lib/dotenvious/cli/main.rb
@@ -11,7 +11,7 @@ module Dotenvious
 
       def run
         parse_options
-        EnvFileConsolidator.new({example_file: options[:file]}).run
+        EnvFileConsolidator.new({example_file: options[:example_file]}).run
         EnvFileSorter.new.run if options[:sort]
       end
 
@@ -23,8 +23,8 @@ module Dotenvious
         parser = OptionParser.new do |opts|
           opts.banner = "How to use Dotenvious:"
 
-          opts.on('-f .example-environment-file', '--file .example-environment-file', 'Specify which example file to use') do |file|
-            options[:file] = file
+          opts.on('-x .example-env-file', '--example .example-env-file', 'Specify which example file to use') do |file|
+            options[:example_file] = file
           end
 
           opts.on('-s', '--sort', 'Sort .env file by key names alphabetically') do

--- a/lib/dotenvious/cli/main.rb
+++ b/lib/dotenvious/cli/main.rb
@@ -11,13 +11,21 @@ module Dotenvious
 
       def run
         parse_options
-        EnvFileConsolidator.new({example_file: options[:example_file]}).run
-        EnvFileSorter.new.run if options[:sort]
+        EnvFileConsolidator.new(file_options).run
+        EnvFileSorter.new(options[:env_file]).run if options[:sort]
       end
 
       private
 
       attr_accessor :options
+      attr_reader :file_options
+
+      def file_options
+        @file_options ||= Hash.new.tap do |hash|
+          hash[:example_file] = options[:example_file] if options.key?(:example_file)
+          hash[:env_file] = options[:env_file] if options.key?(:env_file)
+        end
+      end
 
       def parse_options
         parser = OptionParser.new do |opts|
@@ -27,7 +35,11 @@ module Dotenvious
             options[:example_file] = file
           end
 
-          opts.on('-s', '--sort', 'Sort .env file by key names alphabetically') do
+          opts.on('-f .env-file', '--file .env-file', 'Specify which file to write to') do |file|
+            options[:env_file] = file
+          end
+
+          opts.on('-s', '--sort', 'Sort env file by key names alphabetically') do
             options[:sort] = true
           end
 

--- a/lib/dotenvious/env_appender.rb
+++ b/lib/dotenvious/env_appender.rb
@@ -1,15 +1,19 @@
 module Dotenvious
   class EnvAppender
+    def initialize(filename)
+      @filename = filename
+    end
+
     def append(key)
       env.write("#{key}=#{ENV_EXAMPLE[key]}\n")
     end
 
     private
 
-    attr_reader :env
+    attr_reader :env, :filename
 
     def env
-      @env ||= File.open('.env', 'a+')
+      @env ||= File.open(filename, 'a+')
     end
   end
 end

--- a/lib/dotenvious/loaders/environments.rb
+++ b/lib/dotenvious/loaders/environments.rb
@@ -6,17 +6,18 @@ module Dotenvious
     class Environments
       def initialize(options = {})
         @example_file = options[:example_file] || DEFAULT_EXAMPLE_ENV_FILE
+        @env_file = options[:env_file] || DEFAULT_ENV_FILE
       end
 
       def load_environments
-        ENV.merge!(DotenvFile.load_from('.env'))
+        ENV.merge!(DotenvFile.load_from(env_file))
         environment_loader = example_file.match(/\.ya?ml/) ? YamlFile : DotenvFile
         ENV_EXAMPLE.merge!(environment_loader.load_from(example_file))
       end
 
       private
 
-      attr_reader :example_file
+      attr_reader :example_file, :env_file
     end
   end
 end

--- a/lib/dotenvious/prompter.rb
+++ b/lib/dotenvious/prompter.rb
@@ -5,47 +5,53 @@ require_relative 'env_appender'
 
 module Dotenvious
   class Prompter
-    def self.run
+    def initialize(filename = DEFAULT_ENV_FILE)
+      @filename = filename
+    end
+
+    def run
       keys_in_question.each do |key, status|
         decision = prompt(key, status)
         return if decision == 'q'
         next unless decision.downcase == 'y'
 
         if status == 'missing'
-          EnvAppender.new.append(key)
+          EnvAppender.new(filename).append(key)
         elsif status == 'mismatched'
-          ValueReplacer.new.replace(key)
+          ValueReplacer.new(filename).replace(key)
         end
       end
     end
 
     private
 
-    def self.keys_in_question
+    attr_reader :filename
+
+    def keys_in_question
       missing_keys = missing_vars.zip(['missing'] * missing_vars.length)
       mismatched_keys = mismatched_vars.zip(['mismatched'] * mismatched_vars.length)
       missing_keys + mismatched_keys
     end
 
-    def self.missing_vars
+    def missing_vars
       MissingVariableFinder.missing_required_vars
     end
 
-    def self.mismatched_vars
+    def mismatched_vars
       MismatchedVariableFinder.mismatched_vars
     end
 
-    def self.prompt(var, status)
+    def prompt(var, status)
       send(:"display_#{status}_output", var)
       STDIN.gets.strip
     end
 
-    def self.display_missing_output(var)
+    def display_missing_output(var)
       puts "#{var}=#{ENV_EXAMPLE[var]}"
-      puts "Add to .env? [y/n/q]"
+      puts "Add to #{filename}? [y/n/q]"
     end
 
-    def self.display_mismatched_output(var)
+    def display_mismatched_output(var)
       puts "ENV[#{var}] is set to: #{ENV[var]}"
       puts "Example [#{var}] is set to: #{ENV_EXAMPLE[var]}"
       puts "Replace with the example value? [y/n/q]"

--- a/lib/dotenvious/value_replacer.rb
+++ b/lib/dotenvious/value_replacer.rb
@@ -1,5 +1,9 @@
 module Dotenvious
   class ValueReplacer
+    def initialize(filename)
+      @filename = filename
+    end
+
     def replace(key)
       line_number = base_env.find_index do |line|
         line.match(/^#{key}=/)
@@ -11,14 +15,14 @@ module Dotenvious
 
     private
 
-    attr_reader :base_env
+    attr_reader :base_env, :filename
 
     def base_env
-      @base_env ||= File.read('.env').split("\n")
+      @base_env ||= File.read(filename).split("\n")
     end
 
     def env_writer
-      File.open('.env', 'w')
+      File.open(filename, 'w')
     end
   end
 end

--- a/spec/dotenvious/cli/env_file_consolidator_spec.rb
+++ b/spec/dotenvious/cli/env_file_consolidator_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Dotenvious::CLI::EnvFileConsolidator do
   describe '.new' do
     it 'takes option hash' do
-      expect { described_class.new({example_file: '.envenvenv'}) }.to_not raise_error
+      expect { described_class.new({example_file: '.envenvenv', env_file: '.env'}) }.to_not raise_error
     end
   end
 
@@ -23,9 +23,11 @@ describe Dotenvious::CLI::EnvFileConsolidator do
         context 'and the user wants to append them' do
           it 'begins the Prompter' do
             io_object = double
+            prompter = double
             expect(STDIN).to receive(:gets).and_return('y')
             expect_any_instance_of(described_class).to receive(:all_vars_present?).and_return false
-            expect(Dotenvious::Prompter).to receive(:run)#.and_return false
+            expect(Dotenvious::Prompter).to receive(:new).and_return prompter
+            expect(prompter).to receive(:run)
             described_class.new.run
           end
         end
@@ -56,7 +58,7 @@ describe Dotenvious::CLI::EnvFileConsolidator do
       it 'loads environments with that example_file' do
         environments_double = double
         expect(Dotenvious::Loaders::Environments).to receive(:new)
-          .with({example_file: '.test.env.test'}).and_return(environments_double)
+          .with({example_file: '.test.env.test', env_file: '.env'}).and_return(environments_double)
         expect(environments_double).to receive(:load_environments)
 
         described_class.new({example_file: '.test.env.test'}).run

--- a/spec/dotenvious/cli/main_spec.rb
+++ b/spec/dotenvious/cli/main_spec.rb
@@ -41,9 +41,9 @@ describe Dotenvious::CLI::Main do
           end
         end
 
-        context '--file' do
+        context '--example' do
           before do
-            stub_const('ARGV', ['--file', '.my-test-file-env'])
+            stub_const('ARGV', ['--example', '.my-test-file-env'])
           end
 
           it 'uses the user-specified filename to read example environment' do

--- a/spec/dotenvious/cli/main_spec.rb
+++ b/spec/dotenvious/cli/main_spec.rb
@@ -56,6 +56,22 @@ describe Dotenvious::CLI::Main do
             described_class.new.run
           end
         end
+
+        context '--file' do
+          before do
+            stub_const('ARGV', ['--file', '.my-env'])
+          end
+
+          it 'uses the user-specified filename to read example environment' do
+            fake_consolidator = double
+            expect(fake_consolidator).to receive(:run)
+            expect(Dotenvious::CLI::EnvFileConsolidator).to receive(:new)
+              .with({env_file: '.my-env'})
+              .and_return(fake_consolidator)
+
+            described_class.new.run
+          end
+        end
       end
     end
   end

--- a/spec/dotenvious/env_appender_spec.rb
+++ b/spec/dotenvious/env_appender_spec.rb
@@ -10,10 +10,10 @@ describe Dotenvious::EnvAppender do
       env_double = double('File', write: nil)
       expect(env_double).to receive(:write).with("test2=example2\n")
       expect(File).to receive(:open).
-        with('.env', 'a+').once.
+        with('.big-ol-env', 'a+').once.
         and_return(env_double)
 
-      described_class.new.append('test2')
+      described_class.new('.big-ol-env').append('test2')
     end
   end
 end

--- a/spec/dotenvious/prompter_spec.rb
+++ b/spec/dotenvious/prompter_spec.rb
@@ -11,7 +11,7 @@ describe Dotenvious::Prompter do
     it 'prompts the user to add every missing or mismatched variable do' do
       expect(STDIN).to receive(:gets).twice.and_return('n')
 
-      described_class.run
+      described_class.new.run
     end
 
     it 'appends the vars to .env' do
@@ -20,13 +20,13 @@ describe Dotenvious::Prompter do
         with('.env', 'a+').once.
         and_return(double('File', write: nil))
 
-      described_class.run
+      described_class.new.run
     end
 
     it 'quits out if the user presses q' do
       expect(STDIN).to receive(:gets).once.and_return('q')
 
-      described_class.run
+      described_class.new.run
     end
   end
 end

--- a/spec/dotenvious/value_replacer_spec.rb
+++ b/spec/dotenvious/value_replacer_spec.rb
@@ -7,17 +7,17 @@ describe Dotenvious::ValueReplacer do
     end
     it "replaces the key's value in .env if user presses yes" do
       expect(File).to receive(:read).
-        with('.env').
+        with('.big-ol-env').
         and_return("test=1234\nfake=missing")
 
       env_double = double('File', write: nil)
       expect(env_double).to receive(:write).with("test=1234\nfake=correct")
 
       expect(File).to receive(:open).
-        with('.env', 'w').
+        with('.big-ol-env', 'w').
         and_return(env_double)
 
-      described_class.new.replace('fake')
+      described_class.new('.big-ol-env').replace('fake')
     end
   end
 end


### PR DESCRIPTION
## What's Up

As documented in #18, users should be able to write not only to a `.env` file, but any file they so choose based on their environment configuration. (ie `.env.development`, `.env-test`, etc.)

## What This Does

This PR adds this ability. To do this, it changes the way users set an environment file, from `-f` / `--file` to `-x`/`--example`. Now, the `-f`/`--file` command will take in the file that the user specifies _to be written to_.`