### PR TITLE
Close Files after Writing

### DIFF
--- a/lib/dotenvious/env_appender.rb
+++ b/lib/dotenvious/env_appender.rb
@@ -6,6 +6,7 @@ module Dotenvious
 
     def append(key)
       env.write("#{key}=#{ENV_EXAMPLE[key]}\n")
+      env.close
     end
 
     private

--- a/lib/dotenvious/value_replacer.rb
+++ b/lib/dotenvious/value_replacer.rb
@@ -11,6 +11,7 @@ module Dotenvious
       updated_env = base_env.dup
       updated_env[line_number] = "#{key}=#{ENV_EXAMPLE[key]}"
       env_writer.write(updated_env.join("\n") + "\n")
+      env_writer.close
     end
 
     private
@@ -22,7 +23,7 @@ module Dotenvious
     end
 
     def env_writer
-      File.open(filename, 'w')
+      @env_writer ||= File.open(filename, 'w')
     end
   end
 end

--- a/spec/dotenvious/env_appender_spec.rb
+++ b/spec/dotenvious/env_appender_spec.rb
@@ -9,6 +9,7 @@ describe Dotenvious::EnvAppender do
     it 'appends the value to the end of the .env file' do
       env_double = double('File', write: nil)
       expect(env_double).to receive(:write).with("test2=example2\n")
+      expect(env_double).to receive(:close)
       expect(File).to receive(:open).
         with('.big-ol-env', 'a+').once.
         and_return(env_double)

--- a/spec/dotenvious/prompter_spec.rb
+++ b/spec/dotenvious/prompter_spec.rb
@@ -16,9 +16,13 @@ describe Dotenvious::Prompter do
 
     it 'appends the vars to .env' do
       expect(STDIN).to receive(:gets).twice.and_return('y','n')
+      file_double = double
+      expect(file_double).to receive(:write).with("test2=\n")
+      expect(file_double).to receive(:close)
+
       expect(File).to receive(:open).
         with('.env', 'a+').once.
-        and_return(double('File', write: nil))
+        and_return(file_double)
 
       described_class.new.run
     end
@@ -27,6 +31,9 @@ describe Dotenvious::Prompter do
       expect(STDIN).to receive(:gets).once.and_return('q')
 
       described_class.new.run
+    end
+
+    xit 'given missing and different args, appends/rewrites correctly into env' do
     end
   end
 end

--- a/spec/dotenvious/value_replacer_spec.rb
+++ b/spec/dotenvious/value_replacer_spec.rb
@@ -14,6 +14,7 @@ describe Dotenvious::ValueReplacer do
 
         env_double = double('File', write: nil)
         expect(env_double).to receive(:write).with("test=1234\nfake=correct\n")
+        expect(env_double).to receive(:close)
 
         expect(File).to receive(:open).
           with('.big-ol-env', 'w').


### PR DESCRIPTION
## What's Up

In certain circumstances, the user will want to edit current variables and add new ones. This means that the `EnvAppender` and `ValueReplacer` will both be active. Internally, they both open a `File` for writing/appending.

In both cases, those files were never `.close`d. This means that there are two buffers open to the same file, causing issues about overwriting when both are used.

## What This Does

This PR calls `.close` on the `Files`.

This is more of a hotfix. Really, there should only be one buffer for the `File` at all, and the `Prompter` should do the work of building the new env file and writing once everything is done. Work to come.

Adding an `xit` test to remind myself to write this test when I get to the `Prompter` redesign.