### PR TITLE
[Bug] Add newline at end of final replaced value

### DIFF
--- a/lib/dotenvious/value_replacer.rb
+++ b/lib/dotenvious/value_replacer.rb
@@ -10,7 +10,7 @@ module Dotenvious
       end
       updated_env = base_env.dup
       updated_env[line_number] = "#{key}=#{ENV_EXAMPLE[key]}"
-      env_writer.write(updated_env.join("\n"))
+      env_writer.write(updated_env.join("\n") + "\n")
     end
 
     private

--- a/spec/dotenvious/value_replacer_spec.rb
+++ b/spec/dotenvious/value_replacer_spec.rb
@@ -3,21 +3,24 @@ require 'spec_helper'
 describe Dotenvious::ValueReplacer do
   describe '#replace' do
     before do
-      stub_const('Dotenvious::ENV_EXAMPLE', {'fake' => 'correct'} )
+      stub_const('Dotenvious::ENV_EXAMPLE', example_const )
     end
-    it "replaces the key's value in .env if user presses yes" do
-      expect(File).to receive(:read).
-        with('.big-ol-env').
-        and_return("test=1234\nfake=missing")
+    context 'given a key with a different value' do
+      let(:example_const) { {'fake' => 'correct'} }
+      it "replaces the key's value in .env if user presses yes" do
+        expect(File).to receive(:read).
+          with('.big-ol-env').
+          and_return("test=1234\nfake=missing")
 
-      env_double = double('File', write: nil)
-      expect(env_double).to receive(:write).with("test=1234\nfake=correct")
+        env_double = double('File', write: nil)
+        expect(env_double).to receive(:write).with("test=1234\nfake=correct\n")
 
-      expect(File).to receive(:open).
-        with('.big-ol-env', 'w').
-        and_return(env_double)
+        expect(File).to receive(:open).
+          with('.big-ol-env', 'w').
+          and_return(env_double)
 
-      described_class.new('.big-ol-env').replace('fake')
+        described_class.new('.big-ol-env').replace('fake')
+      end
     end
   end
 end


### PR DESCRIPTION
## What's Up

Depending on ordering of what the user is copying over from their example file, Dotenvious might not append a newline to the end of the env file.

Without a newline, the CLI ends up writing multiple variables on the same line, which renders them ineffective.

## What This Does

This PR adds an extra `\n` at the end of the `ValueReplacer`, which will ensure that subsequent runs won't add variables on the same line.